### PR TITLE
Dodanie materialow z warsztatow grafowych

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,3 @@ site/search/search_index.json
 site/sitemap.xml
 site/sitemap.xml.gz
 site/style.css
-
-docs/Szkolenia/grafy/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ site/search/search_index.json
 site/sitemap.xml
 site/sitemap.xml.gz
 site/style.css
+
+docs/Szkolenia/grafy/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "docs/Szkolenia/grafy"]
+	path = docs/Szkolenia/grafy
+	url = https://github.com/kubajal/hpc-docs-graphs.git
+	branch = stable

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "docs/Szkolenia/grafy"]
+	path = docs/Szkolenia/grafy
+	url = https://github.com/kubajal/hpc-docs-graphs.git
+  branch = stable

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "docs/Szkolenia/grafy"]
-	path = docs/Szkolenia/grafy
-	url = https://github.com/kubajal/hpc-docs-graphs.git
-  branch = stable

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,8 +14,12 @@ theme:
 
 plugins:
   - search # necessary for search to work
+  - mkdocs-jupyter:
+      include_source: True
   - git-revision-date-localized:
       type: date
+      exclude:
+      - '*.ipynb'
   - monorepo
 
 extra_css:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ plugins:
   - search # necessary for search to work
   - git-revision-date-localized:
       type: date
+  - monorepo
 
 extra_css:
     - style.css
@@ -133,7 +134,7 @@ nav:
     - Wprowadzenie do obliczeń na komputerach ICM 2019: Szkolenia/intro_icm_2019.md
     - Wprowadzenie do obliczeń wektorowych – NEC SX-Aurora Tsubasa: Szkolenia/intro_nec.md
     - Effective Neural Networks Without GPU (SOL): Szkolenia/intro_sol.md
-    - Obliczenia grafowe i sieciowe: Szkolenia/intro_grafy.md
+    - Obliczenia grafowe i sieciowe: '!include docs/Szkolenia/grafy/mkdocs.yml'
   - Archiwum: Szkolenia/archiwum.md
 - Sesje użytkowników KDM:
   - Aktualności: Sesje_KDM/aktualnosci.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ mkdocs-material
 python-markdown-math
 mkdocs-git-revision-date-localized-plugin
 pymdown-extensions
+mkdocs-monorepo-plugin
+mkdocs-jupyter


### PR DESCRIPTION
Proponuję, żeby dokumentacja grafów była pod https://github.com/kubajal/hpc-docs-graphs i żeby https://github.com/icm-uw/hpc-docs dociągało to repo jako submoduł. Czyli działanie byłoby takie:

```
git clone https://github.com/icm-uw/hpc-docs.git
git submodule update --init --recursive
git submodule update --recursive --remote
mkdocs serve
```

Dodane nowe pluginy:

- mkdocs-monorepo-plugin: dzięki niemu można kompilować kilka projektów MkDocs w jeden (ten plugin umożliwia taki syntaks w `nav` (w `strona1.yml` jest rozpisana reszta podnawigacji):
  ```
  nav:
    blabla: blabla.md
    strona1: strona1.yml
  ```
- mkdocs-jupyter: ładne wyświetlanie Jupyter Notebooków w MkDocs